### PR TITLE
Mssxtn patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Pacman depends on the following packages:
 Most of these are not part of the LFS book, so download their sources manually:
 
 - libarchive: <https://www.libarchive.org/downloads/libarchive-3.3.2.tar.gz>
-- fakeroot: <http://ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.22.orig.tar.bz2>
+- fakeroot: <http://turul.canonical.com/pool/main/f/fakeroot/fakeroot_1.22.orig.tar.bz2>
 - pacman: <https://sources.archlinux.org/other/pacman/pacman-5.0.2.tar.gz>
 
 Build these packages using the following commands. Just like the LFS book, these commands assume you've extracted the relevant sources and `cd`'d into the resulting directory.

--- a/packages/fakeroot/PKGBUILD
+++ b/packages/fakeroot/PKGBUILD
@@ -3,7 +3,7 @@ pkgver=1.22
 pkgrel=2
 pkgdesc="Tool for simulating superuser privileges"
 arch=('x86_64')
-url="http://packages.debian.org/fakeroot"
+url="http://turul.canonical.com/pool/main/f/fakeroot/"
 license=('GPL')
 source=(${pkgname}_${pkgver}.orig.tar.bz2
 	silence-dlerror.patch)


### PR DESCRIPTION
Fixed broken link for fakeroot sources. Debian repo no longer has fakeroot 1.22. They have 1.21 and 1.23, but no 1.22 for some reason.

I exercised google-fu and found a repository for Ubuntu that still had fakeroot_1.22.orig.tar.bz hosted.